### PR TITLE
Updated fdroid to version 0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ MAINTAINER Francois-Xavier Aguessy <fxaguessy@users.noreply.github.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository ppa:guardianproject/ppa
+RUN apt-get update && apt-get install -y \
 	fdroidserver \
 	git \
 	lib32stdc++6 \


### PR DESCRIPTION
I've updated fdroid to version 0.7 by using Guardian Project PPA as suggested by the developers. This fixes an [issue](https://gitlab.com/fdroid/fdroidserver/issues/199) in handling some manifests.