### PR TITLE
Added update button to web interface.

### DIFF
--- a/gplayweb
+++ b/gplayweb
@@ -51,6 +51,8 @@ class MainHandler(tornado.web.RequestHandler):
 			self.empty_cache()
 		elif page == 'fdroid-forceupdate':
 			self.fdroid_forceupdate()
+                elif page == 'updateapks':
+                        self.update_apks()
 		else:
 			return
 
@@ -108,6 +110,10 @@ class MainHandler(tornado.web.RequestHandler):
 	def fdroid_forceupdate(self):
 		self.update_fdroid()
 		self.redirect('list')
+
+        def update_apks(self):
+                self.cli.prepare_analyse_apks()
+                self.redirect('list')
 
 	# Search an apk by string
 	def search(self):
@@ -270,6 +276,8 @@ def main():
 
 	# Parsing conffile
 	cli = GPlaycli(cli_args.CONFFILE)
+        # Auto confirm cli actions
+        cli.yes = True
 	# Connect to API
 	cli.connect_to_googleplay_api()
 

--- a/gplayweb.conf.example
+++ b/gplayweb.conf.example
@@ -3,6 +3,7 @@ gmail_password=zHbdWdWtvdQAfylf
 android_ID=3d716411bf8bc802
 gmail_address=fdroidserver@gmail.com
 language=fr_FR
+download_folder_path=/data/fdroid/repo
 [Server]
 folder=/data/fdroid/repo
 root_url=/

--- a/templates/base.html
+++ b/templates/base.html
@@ -92,6 +92,7 @@
 			    <li><a href="{{ROOT}}?page=download"><span class="glyphicon glyphicon-download-alt"><span class="menu-name">  Download</span></span></a></li>
 			    <li><a href="{{ROOT}}?page=fdroid-forceupdate"><span class="glyphicon  glyphicon glyphicon-refresh"><span class="menu-name"> Fdroid force update</span></span></a></li>
 			    <li><a href="{{ROOT}}?page=emptycache"><span class="glyphicon  glyphicon glyphicon-refresh"><span class="menu-name">  Clear cache</span></span></a></li>
+			    <li><a href="{{ROOT}}?page=updateapks"><span class="glyphicon  glyphicon glyphicon-refresh"><span class="menu-name">  Update APKs</span></span></a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Added a mapping to the gplaycli function which updates all the downloaded APKs.
Set the cli.yes flag to avoid timeouts due to missing command line confirmation.
One thing to improve is that when all the apps are up to date, the web app returns ERR_EMPTY_RESPONSE, while it would be nice to have a message printed on the webpage.
The prepare_analyse_apks exits when it has finished, in this way we cannot redirect back to the 'list' page.